### PR TITLE
support progress on webview

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -10,7 +10,9 @@ import android.hardware.display.DisplayManager;
 import android.os.Build;
 import android.os.Handler;
 import android.view.View;
+import android.webkit.WebChromeClient;
 import android.webkit.WebStorage;
+import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
@@ -304,6 +306,17 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
           final boolean debuggingEnabled = (boolean) settings.get(key);
 
           webView.setWebContentsDebuggingEnabled(debuggingEnabled);
+          break;
+        case "hasProgressTracking":
+          final boolean progressTrackingEnabled = (boolean) settings.get(key);
+          if (progressTrackingEnabled) {
+            webView.setWebChromeClient(
+                new WebChromeClient() {
+                  public void onProgressChanged(WebView view, int progress) {
+                    flutterWebViewClient.onLoadingProgress(progress);
+                  }
+                });
+          }
           break;
         case "userAgent":
           updateUserAgent((String) settings.get(key));

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -24,6 +24,7 @@ class FlutterWebViewClient {
   private static final String TAG = "FlutterWebViewClient";
   private final MethodChannel methodChannel;
   private boolean hasNavigationDelegate;
+  private boolean hasProgressTracking;
 
   FlutterWebViewClient(MethodChannel methodChannel) {
     this.methodChannel = methodChannel;
@@ -70,6 +71,12 @@ class FlutterWebViewClient {
     Map<String, Object> args = new HashMap<>();
     args.put("url", url);
     methodChannel.invokeMethod("onPageFinished", args);
+  }
+
+  void onLoadingProgress(int progress) {
+    Map<String, Object> args = new HashMap<>();
+    args.put("progress", progress);
+    methodChannel.invokeMethod("onProgress", args);
   }
 
   private void notifyOnNavigationRequest(

--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -69,6 +69,9 @@ class _WebViewExampleState extends State<WebViewExample> {
           onPageFinished: (String url) {
             print('Page finished loading: $url');
           },
+          onProgress: (int progress) {
+            print("WebView is loading (progress : $progress%)");
+          },
         );
       }),
       floatingActionButton: favoriteButton(),

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.h
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FLTWKNavigationDelegate : NSObject <WKNavigationDelegate>
 
-- (instancetype)initWithChannel:(FlutterMethodChannel*)channel;
+- (instancetype)initWithChannel:(FlutterMethodChannel *)channel;
 
 /**
  * Whether to delegate navigation decisions over the method channel.

--- a/packages/webview_flutter/ios/Classes/FLTWKProgressionDelegate.h
+++ b/packages/webview_flutter/ios/Classes/FLTWKProgressionDelegate.h
@@ -1,0 +1,22 @@
+//
+//  FLTWKProgressionDelegate.h
+//  webview_flutter
+//
+//  Created by Jérémie Vincke on 03/10/2019.
+//
+
+#import <Flutter/Flutter.h>
+#import <Foundation/Foundation.h>
+#import <WebKit/WebKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FLTWKProgressionDelegate : NSObject
+
+- (instancetype)initWithWebView:(WKWebView *)webView channel:(FlutterMethodChannel *)channel;
+
+- (void)stopObservingProgress:(WKWebView *)webView;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/webview_flutter/ios/Classes/FLTWKProgressionDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKProgressionDelegate.m
@@ -1,0 +1,45 @@
+//
+//  FLTWKProgressionDelegate.m
+//  webview_flutter
+//
+//  Created by Jérémie Vincke on 03/10/2019.
+//
+
+#import "FLTWKProgressionDelegate.h"
+
+NSString *const keyPath = @"estimatedProgress";
+
+@implementation FLTWKProgressionDelegate {
+  FlutterMethodChannel *_methodChannel;
+}
+
+- (instancetype)initWithWebView:(WKWebView *)webView channel:(FlutterMethodChannel *)channel {
+  self = [super init];
+  if (self) {
+    _methodChannel = channel;
+    [webView addObserver:self
+              forKeyPath:keyPath
+                 options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
+                 context:nil];
+  }
+  return self;
+}
+
+- (void)stopObservingProgress:(WKWebView *)webView {
+  [webView removeObserver:self forKeyPath:keyPath];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSKeyValueChangeKey, id> *)change
+                       context:(void *)context {
+  if ([keyPath isEqualToString:keyPath]) {
+    NSNumber *newValue =
+        change[NSKeyValueChangeNewKey] ?: 0;          // newValue is anywhere between 0.0 and 1.0
+    int newValueAsInt = [newValue floatValue] * 100;  // Anywhere between 0 and 100
+    [_methodChannel invokeMethod:@"onProgress"
+                       arguments:@{@"progress" : [NSNumber numberWithInt:newValueAsInt]}];
+  }
+}
+
+@end

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -4,6 +4,7 @@
 
 #import "FlutterWebView.h"
 #import "FLTWKNavigationDelegate.h"
+#import "FLTWKProgressionDelegate.h"
 #import "JavaScriptChannelHandler.h"
 
 @implementation FLTWebViewFactory {
@@ -46,6 +47,7 @@
   // The set of registered JavaScript channel names.
   NSMutableSet* _javaScriptChannelNames;
   FLTWKNavigationDelegate* _navigationDelegate;
+  FLTWKProgressionDelegate* _progressionDelegate;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -92,6 +94,12 @@
     }
   }
   return self;
+}
+
+- (void)dealloc {
+  if (_progressionDelegate != nil) {
+    [_progressionDelegate stopObservingProgress:_webView];
+  }
 }
 
 - (UIView*)view {
@@ -274,6 +282,12 @@
     } else if ([key isEqualToString:@"hasNavigationDelegate"]) {
       NSNumber* hasDartNavigationDelegate = settings[key];
       _navigationDelegate.hasDartNavigationDelegate = [hasDartNavigationDelegate boolValue];
+    } else if ([key isEqualToString:@"hasProgressTracking"]) {
+      NSNumber* hasProgressTrackingValue = settings[key];
+      bool hasProgressTracking = [hasProgressTrackingValue boolValue];
+      if (hasProgressTracking) {
+        _progressionDelegate = [[FLTWKProgressionDelegate alloc] initWithWebView:_webView channel:_channel];
+      }
     } else if ([key isEqualToString:@"debuggingEnabled"]) {
       // no-op debugging is always enabled on iOS.
     } else if ([key isEqualToString:@"userAgent"]) {

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -26,6 +26,9 @@ abstract class WebViewPlatformCallbacksHandler {
 
   /// Invoked by [WebViewPlatformController] when a page has finished loading.
   void onPageFinished(String url);
+
+  /// Invoked by [WebViewPlatformController] when a page is loading.
+  void onProgress(int progress);
 }
 
 /// Interface for talking to the webview's platform implementation.
@@ -230,6 +233,7 @@ class WebSettings {
   WebSettings({
     this.javascriptMode,
     this.hasNavigationDelegate,
+    this.hasProgressTracking,
     this.debuggingEnabled,
     @required this.userAgent,
   }) : assert(userAgent != null);
@@ -239,6 +243,9 @@ class WebSettings {
 
   /// Whether the [WebView] has a [NavigationDelegate] set.
   final bool hasNavigationDelegate;
+
+  /// Whether the [WebView] should track page loading progress.
+  final bool hasProgressTracking;
 
   /// Whether to enable the platform's webview content debugging tools.
   ///
@@ -257,7 +264,7 @@ class WebSettings {
 
   @override
   String toString() {
-    return 'WebSettings(javascriptMode: $javascriptMode, hasNavigationDelegate: $hasNavigationDelegate, debuggingEnabled: $debuggingEnabled, userAgent: $userAgent,)';
+    return 'WebSettings(javascriptMode: $javascriptMode, hasNavigationDelegate: $hasNavigationDelegate, hasProgressTracking: $hasProgressTracking, debuggingEnabled: $debuggingEnabled, userAgent: $userAgent,)';
   }
 }
 

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -39,6 +39,9 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       case 'onPageFinished':
         _platformCallbacksHandler.onPageFinished(call.arguments['url']);
         return null;
+      case 'onProgress':
+        _platformCallbacksHandler.onProgress(call.arguments['progress']);
+        return null;
     }
     throw MissingPluginException(
         '${call.method} was invoked but has no handler');
@@ -136,6 +139,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
 
     _addIfNonNull('jsMode', settings.javascriptMode?.index);
     _addIfNonNull('hasNavigationDelegate', settings.hasNavigationDelegate);
+    _addIfNonNull('hasProgressTracking', settings.hasProgressTracking);
     _addIfNonNull('debuggingEnabled', settings.debuggingEnabled);
     _addSettingIfPresent('userAgent', settings.userAgent);
     return map;

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -658,6 +658,62 @@ void main() {
     });
   });
 
+  group('$PageLoadingCallback', () {
+    testWidgets('onLoadingProgress is not null', (WidgetTester tester) async {
+      int loadingProgress;
+
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onProgress: (int progress) {
+          loadingProgress = progress;
+        },
+      ));
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView;
+
+      platformWebView.fakeOnProgressCallback(50);
+
+      expect(loadingProgress, 50);
+    });
+
+    testWidgets('onLoadingProgress is null', (WidgetTester tester) async {
+      await tester.pumpWidget(const WebView(
+        initialUrl: 'https://youtube.com',
+        onProgress: null,
+      ));
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView;
+
+      // This is to test that it does not crash on a null callback.
+      platformWebView.fakeOnProgressCallback(50);
+    });
+
+    testWidgets('onLoadingProgress changed', (WidgetTester tester) async {
+      int loadingProgress;
+
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onProgress: (int progress) {},
+      ));
+
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onProgress: (int progress) {
+          loadingProgress = progress;
+        },
+      ));
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView;
+
+      platformWebView.fakeOnProgressCallback(50);
+
+      expect(loadingProgress, 50);
+    });
+  });
+
   group('navigationDelegate', () {
     testWidgets('hasNavigationDelegate', (WidgetTester tester) async {
       await tester.pumpWidget(const WebView(
@@ -983,6 +1039,24 @@ class FakePlatformWebView {
       channel.name,
       data,
       (ByteData data) {},
+    );
+  }
+
+  void fakeOnProgressCallback(int progress) {
+    final StandardMethodCodec codec = const StandardMethodCodec();
+
+    final ByteData data = codec.encodeMethodCall(MethodCall(
+      'onProgress',
+      <dynamic, dynamic>{'progress': progress},
+    ));
+
+    // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
+    // https://github.com/flutter/flutter/issues/33446
+    // ignore: deprecated_member_use
+    BinaryMessages.handlePlatformMessage(
+      channel.name,
+      data,
+          (ByteData data) {},
     );
   }
 


### PR DESCRIPTION
**Description**
Support for loading progress tracking

No existing behaviour was modified ; the user of this plugin can choose whether the webView's loading progress should be tracked by setting the webView's onProgress callback.