### PR TITLE
1. Add onPageStarted, onPageReceivedError callbacks.

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -5,12 +5,16 @@
 package io.flutter.plugins.webviewflutter;
 
 import android.annotation.TargetApi;
+import android.graphics.Bitmap;
 import android.os.Build;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import androidx.webkit.WebResourceErrorCompat;
 import androidx.webkit.WebViewClientCompat;
 import io.flutter.plugin.common.MethodChannel;
 import java.util.HashMap;
@@ -92,6 +96,20 @@ class FlutterWebViewClient {
     }
   }
 
+  private void onReceiveError(WebView view, int code, String description, String url) {
+    Map<String, Object> args = new HashMap<>();
+    args.put("url", url);
+    args.put("code", code);
+    args.put("description", description);
+    methodChannel.invokeMethod("onPageReceiveError", args);
+  }
+
+  private void onPageStarted(WebView view, String url) {
+    Map<String, Object> args = new HashMap<>();
+    args.put("url", url);
+    methodChannel.invokeMethod("onPageStarted", args);
+  }
+
   // This method attempts to avoid using WebViewClientCompat due to bug
   // https://bugs.chromium.org/p/chromium/issues/detail?id=925887. Also, see
   // https://github.com/flutter/flutter/issues/29446.
@@ -118,6 +136,37 @@ class FlutterWebViewClient {
         FlutterWebViewClient.this.onPageFinished(view, url);
       }
 
+      @TargetApi(Build.VERSION_CODES.M)
+      @Override
+      public void onReceivedError(
+          WebView view, WebResourceRequest request, WebResourceError error) {
+        FlutterWebViewClient.this.onReceiveError(
+            view,
+            error.getErrorCode(),
+            error.getDescription().toString(),
+            request.getUrl().toString());
+      }
+
+      @TargetApi(Build.VERSION_CODES.M)
+      @Override
+      public void onReceivedHttpError(
+          WebView view, WebResourceRequest request, WebResourceResponse errorResponse) {
+        FlutterWebViewClient.this.onReceiveError(
+            view, errorResponse.getStatusCode(), null, request.getUrl().toString());
+      }
+
+      @SuppressWarnings("deprecation")
+      @Override
+      public void onReceivedError(
+          WebView view, int errorCode, String description, String failingUrl) {
+        FlutterWebViewClient.this.onReceiveError(view, errorCode, description, failingUrl);
+      }
+
+      @Override
+      public void onPageStarted(WebView view, String url, Bitmap favicon) {
+        FlutterWebViewClient.this.onPageStarted(view, url);
+      }
+
       @Override
       public void onUnhandledKeyEvent(WebView view, KeyEvent event) {
         // Deliberately empty. Occasionally the webview will mark events as having failed to be
@@ -142,6 +191,42 @@ class FlutterWebViewClient {
       @Override
       public void onPageFinished(WebView view, String url) {
         FlutterWebViewClient.this.onPageFinished(view, url);
+      }
+
+      @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+      @Override
+      public void onReceivedHttpError(
+          @NonNull WebView view,
+          @NonNull WebResourceRequest request,
+          @NonNull WebResourceResponse errorResponse) {
+        FlutterWebViewClient.this.onReceiveError(
+            view, errorResponse.getStatusCode(), null, request.getUrl().toString());
+      }
+
+      @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+      @Override
+      public void onReceivedError(
+          @NonNull WebView view,
+          @NonNull WebResourceRequest request,
+          @NonNull WebResourceErrorCompat error) {
+        //TODO: is really need to check WebViewFeature.isFeatureSupported() and api version.
+        FlutterWebViewClient.this.onReceiveError(
+            view,
+            error.getErrorCode(),
+            error.getDescription().toString(),
+            request.getUrl().toString());
+      }
+
+      @SuppressWarnings("deprecation")
+      @Override
+      public void onReceivedError(
+          WebView view, int errorCode, String description, String failingUrl) {
+        FlutterWebViewClient.this.onReceiveError(view, errorCode, description, failingUrl);
+      }
+
+      @Override
+      public void onPageStarted(WebView view, String url, Bitmap favicon) {
+        FlutterWebViewClient.this.onPageStarted(view, url);
       }
 
       @Override

--- a/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
+++ b/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
@@ -494,7 +494,126 @@ void main() {
     final String title = await controller.getTitle();
     expect(title, 'Some title');
   });
+
+  group('NavigationDelegate', () {
+    final String blankPage = "<!DOCTYPE html><head></head><body></body></html>";
+    final String blankPageEncoded = 'data:text/html;charset=utf-8;base64,' +
+        base64Encode(const Utf8Encoder().convert(blankPage));
+
+    testWidgets('can allow requests', (WidgetTester tester) async {
+      final Completer<WebViewController> controllerCompleter =
+      Completer<WebViewController>();
+      final StreamController<String> pageLoads =
+      StreamController<String>.broadcast();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: WebView(
+            key: GlobalKey(),
+            initialUrl: blankPageEncoded,
+            onWebViewCreated: (WebViewController controller) {
+              controllerCompleter.complete(controller);
+            },
+            javascriptMode: JavascriptMode.unrestricted,
+            navigationDelegate: (NavigationRequest request) {
+              return (request.url.contains('youtube.com'))
+                  ? NavigationDecision.prevent
+                  : NavigationDecision.navigate;
+            },
+            onPageFinished: (String url) => pageLoads.add(url),
+          ),
+        ),
+      );
+
+      await pageLoads.stream.first; // Wait for initial page load.
+      final WebViewController controller = await controllerCompleter.future;
+      await controller
+          .evaluateJavascript('location.href = "https://www.google.com/"');
+
+      await pageLoads.stream.first; // Wait for the next page load.
+      final String currentUrl = await controller.currentUrl();
+      expect(currentUrl, 'https://www.google.com/');
+    });
+
+    testWidgets('can block requests', (WidgetTester tester) async {
+      final Completer<WebViewController> controllerCompleter =
+      Completer<WebViewController>();
+      final StreamController<String> pageLoads =
+      StreamController<String>.broadcast();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: WebView(
+            key: GlobalKey(),
+            initialUrl: blankPageEncoded,
+            onWebViewCreated: (WebViewController controller) {
+              controllerCompleter.complete(controller);
+            },
+            javascriptMode: JavascriptMode.unrestricted,
+            navigationDelegate: (NavigationRequest request) {
+              return (request.url.contains('youtube.com'))
+                  ? NavigationDecision.prevent
+                  : NavigationDecision.navigate;
+            },
+            onPageFinished: (String url) => pageLoads.add(url),
+          ),
+        ),
+      );
+
+      await pageLoads.stream.first; // Wait for initial page load.
+      final WebViewController controller = await controllerCompleter.future;
+      await controller
+          .evaluateJavascript('location.href = "https://www.youtube.com/"');
+
+      // There should never be any second page load, since our new URL is
+      // blocked. Still wait for a potential page change for some time in order
+      // to give the test a chance to fail.
+      await pageLoads.stream.first
+          .timeout(const Duration(milliseconds: 500), onTimeout: () => null);
+      final String currentUrl = await controller.currentUrl();
+      expect(currentUrl, isNot(contains('youtube.com')));
+    });
+
+    testWidgets('supports asynchronous decisions', (WidgetTester tester) async {
+      final Completer<WebViewController> controllerCompleter =
+      Completer<WebViewController>();
+      final StreamController<String> pageLoads =
+      StreamController<String>.broadcast();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: WebView(
+            key: GlobalKey(),
+            initialUrl: blankPageEncoded,
+            onWebViewCreated: (WebViewController controller) {
+              controllerCompleter.complete(controller);
+            },
+            javascriptMode: JavascriptMode.unrestricted,
+            navigationDelegate: (NavigationRequest request) async {
+              NavigationDecision decision = NavigationDecision.prevent;
+              decision = await Future<NavigationDecision>.delayed(
+                  const Duration(milliseconds: 10),
+                      () => NavigationDecision.navigate);
+              return decision;
+            },
+            onPageFinished: (String url) => pageLoads.add(url),
+          ),
+        ),
+      );
+
+      await pageLoads.stream.first; // Wait for initial page load.
+      final WebViewController controller = await controllerCompleter.future;
+      await controller
+          .evaluateJavascript('location.href = "https://www.google.com"');
+
+      await pageLoads.stream.first; // Wait for second page to load.
+      final String currentUrl = await controller.currentUrl();
+      expect(currentUrl, 'https://www.google.com/');
+    });
+  });
 }
+
+
 
 // JavaScript booleans evaluate to different string values on Android and iOS.
 // This utility method returns the string boolean value of the current platform.

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
@@ -59,4 +59,55 @@
 - (void)webView:(WKWebView*)webView didFinishNavigation:(WKNavigation*)navigation {
   [_methodChannel invokeMethod:@"onPageFinished" arguments:@{@"url" : webView.URL.absoluteString}];
 }
+
+- (void)webView:(WKWebView *)webView
+    didFailNavigation:(WKNavigation *)navigation
+            withError:(NSError *)error {
+  NSDictionary *arguments = @{
+    @"url" : webView.URL.absoluteString ?: [NSNull null],
+    @"code" : [NSNumber numberWithLong:error.code],
+    @"description" : [error localizedDescription],
+  };
+
+  [_methodChannel invokeMethod:@"onPageReceiveError" arguments:arguments];
+}
+
+- (void)webView:(WKWebView *)webView
+    didFailProvisionalNavigation:(WKNavigation *)navigation
+                       withError:(NSError *)error {
+  NSDictionary *arguments = @{
+    @"url" : error.userInfo[NSURLErrorFailingURLStringErrorKey],
+    @"code" : [NSNumber numberWithLong:error.code],
+    @"description" : [error localizedDescription],
+  };
+
+  [_methodChannel invokeMethod:@"onPageReceiveError" arguments:arguments];
+}
+
+- (void)webView:(WKWebView *)webView
+    decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse
+                      decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler {
+  if ([navigationResponse.response isKindOfClass:[NSHTTPURLResponse class]]) {
+    NSHTTPURLResponse *response = (NSHTTPURLResponse *)navigationResponse.response;
+    if (response.statusCode >= 400 && response.statusCode < 600) {
+      NSDictionary *arguments = @{
+        @"url" : response.URL.absoluteString ?: [NSNull null],
+        @"code" : [NSNumber numberWithLong:response.statusCode],
+        @"description" : [NSHTTPURLResponse localizedStringForStatusCode:response.statusCode],
+      };
+
+      [_methodChannel invokeMethod:@"onPageReceiveError" arguments:arguments];
+    }
+  }
+
+  decisionHandler(WKNavigationResponsePolicyAllow);
+}
+
+- (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation {
+  [_methodChannel invokeMethod:@"onPageStarted"
+                     arguments:@{
+                       @"url" : webView.URL.absoluteString ?: [NSNull null],
+                     }];
+}
+
 @end

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -22,10 +22,16 @@ abstract class WebViewPlatformCallbacksHandler {
   /// Invoked by [WebViewPlatformController] when a navigation request is pending.
   ///
   /// If true is returned the navigation is allowed, otherwise it is blocked.
-  bool onNavigationRequest({String url, bool isForMainFrame});
+  FutureOr<bool> onNavigationRequest({String url, bool isForMainFrame});
 
   /// Invoked by [WebViewPlatformController] when a page has finished loading.
   void onPageFinished(String url);
+
+  /// Invoked by [WebViewPlatformController] when a page has Receive Error.
+  void onPageReceiveError({String url, int code, String description});
+
+  /// Invoked by [WebViewPlatformController] when a page has Started.
+  void onPageStarted(String url);
 
   /// Invoked by [WebViewPlatformController] when a page is loading.
   void onProgress(int progress);

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -32,12 +32,21 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
         _platformCallbacksHandler.onJavaScriptChannelMessage(channel, message);
         return true;
       case 'navigationRequest':
-        return _platformCallbacksHandler.onNavigationRequest(
+        return await _platformCallbacksHandler.onNavigationRequest(
           url: call.arguments['url'],
           isForMainFrame: call.arguments['isForMainFrame'],
         );
       case 'onPageFinished':
         _platformCallbacksHandler.onPageFinished(call.arguments['url']);
+        return null;
+      case 'onPageReceiveError':
+        _platformCallbacksHandler.onPageReceiveError(
+            url: call.arguments['url'],
+            code: call.arguments['code'],
+            description: call.arguments['description']);
+        return null;
+      case 'onPageStarted':
+        _platformCallbacksHandler.onPageStarted(call.arguments['url']);
         return null;
       case 'onProgress':
         _platformCallbacksHandler.onProgress(call.arguments['progress']);

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -886,6 +886,128 @@ void main() {
 
     expect(platformWebView.userAgent, 'UA');
   });
+
+  group('$PageReceiveErrorCallback', () {
+    testWidgets('onPageReceiveError is not null', (WidgetTester tester) async {
+      String returnedUrl;
+      int returnedCode;
+      String returnedDescription;
+
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageReceiveError: (String url, int code, String description) {
+          returnedUrl = url;
+          returnedCode = code;
+          returnedDescription = description;
+        },
+      ));
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView;
+
+      platformWebView.fakeOnPageReceiveErrorCallback(404, "description");
+
+      expect(platformWebView.currentUrl, returnedUrl);
+      expect(404, returnedCode);
+      expect("description", returnedDescription);
+    });
+
+    testWidgets('onPageReceiveError is null', (WidgetTester tester) async {
+      await tester.pumpWidget(const WebView(
+        initialUrl: 'https://youtube.com',
+        onPageReceiveError: null,
+      ));
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView;
+
+      platformWebView.fakeOnPageReceiveErrorCallback(404, "description");
+    });
+
+    testWidgets('onPageReceiveError changed', (WidgetTester tester) async {
+      String returnedUrl;
+      int returnedCode;
+      String returnedDescription;
+
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageReceiveError: (String url, int code, String description) {},
+      ));
+
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageReceiveError: (String url, int code, String description) {
+          returnedUrl = url;
+          returnedCode = code;
+          returnedDescription = description;
+        },
+      ));
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView;
+
+      platformWebView.fakeOnPageReceiveErrorCallback(404, "description");
+
+      expect(platformWebView.currentUrl, returnedUrl);
+      expect(404, returnedCode);
+      expect("description", returnedDescription);
+    });
+  });
+
+  group('$PageStartedCallback', () {
+    testWidgets('onPageStarted is not null', (WidgetTester tester) async {
+      String returnedUrl;
+
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageStarted: (String url) {
+          returnedUrl = url;
+        },
+      ));
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView;
+
+      platformWebView.fakeOnPageStartedCallback();
+
+      expect(platformWebView.currentUrl, returnedUrl);
+    });
+
+    testWidgets('onPageStarted is null', (WidgetTester tester) async {
+      await tester.pumpWidget(const WebView(
+        initialUrl: 'https://youtube.com',
+        onPageStarted: null,
+      ));
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView;
+
+      platformWebView.fakeOnPageStartedCallback();
+    });
+
+    testWidgets('onPageStarted changed', (WidgetTester tester) async {
+      String returnedUrl;
+
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageStarted: (String url) {},
+      ));
+
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageStarted: (String url) {
+          returnedUrl = url;
+        },
+      ));
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView;
+
+      platformWebView.fakeOnPageStartedCallback();
+
+      expect(platformWebView.currentUrl, returnedUrl);
+    });
+  });
 }
 
 class FakePlatformWebView {
@@ -1048,6 +1170,46 @@ class FakePlatformWebView {
     final ByteData data = codec.encodeMethodCall(MethodCall(
       'onProgress',
       <dynamic, dynamic>{'progress': progress},
+    ));
+
+    // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
+    // https://github.com/flutter/flutter/issues/33446
+    // ignore: deprecated_member_use
+    BinaryMessages.handlePlatformMessage(
+      channel.name,
+      data,
+          (ByteData data) {},
+    );
+  }
+
+  void fakeOnPageReceiveErrorCallback(int code, String description) {
+    final StandardMethodCodec codec = const StandardMethodCodec();
+
+    final ByteData data = codec.encodeMethodCall(MethodCall(
+      'onPageReceiveError',
+      <dynamic, dynamic>{
+        'url': currentUrl,
+        'code': code,
+        'description': description
+      },
+    ));
+
+    // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
+    // https://github.com/flutter/flutter/issues/33446
+    // ignore: deprecated_member_use
+    BinaryMessages.handlePlatformMessage(
+      channel.name,
+      data,
+          (ByteData data) {},
+    );
+  }
+
+  void fakeOnPageStartedCallback() {
+    final StandardMethodCodec codec = const StandardMethodCodec();
+
+    final ByteData data = codec.encodeMethodCall(MethodCall(
+      'onPageStarted',
+      <dynamic, dynamic>{'url': currentUrl},
     ));
 
     // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.


### PR DESCRIPTION
1. Add onPageStarted, onPageReceivedError callbacks.
We can catch iOS or Android specific error сodes and http status codes.

2. Previously all navigation decisions needed to be made synchronously in Dart. 
The platform layers are already waiting for the MethodChannel callback, so just changed the return type to be FutureOr<NavigationDecision>'. This is a change to the method signature of WebViewPlatformCallbacksHandler#onNavigationRequest, but that interface appears to only be meant to be implemented internally to the plugin.

